### PR TITLE
Add tests for jwtutil with mocked dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -104,10 +104,9 @@
         </dependency>
 
 
-
-
         <!-- Test Dependencies -->
         <dependency>
+
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
@@ -126,6 +125,13 @@
             <artifactId>joda-time</artifactId>
             <version>2.10.14</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/mycompany/util/JwtUtil.java
+++ b/src/main/java/com/mycompany/util/JwtUtil.java
@@ -9,44 +9,36 @@ import io.jsonwebtoken.SignatureException;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
-
 public class JwtUtil {
 
-   private static final String SECRET_KEY;
+    private static final String SECRET_KEY;
 
     static {
         Dotenv dotenv = Dotenv.configure()
-                .ignoreIfMissing() // Don't fail if .env doesn't exist
+                .ignoreIfMissing()
                 .load();
 
-        // Try to load from .env first
         String envKey = dotenv.get("JWT_SECRET_KEY");
         String systemKey = System.getenv("JWT_SECRET_KEY");
 
-        // Use the first non-null key found
         SECRET_KEY = envKey != null ? envKey : (systemKey != null ? systemKey : "defaultFallbackSecret");
-
     }
 
-
-    // Method to return the secret key as a byte array
     public static byte[] getSecretKey() {
         return SECRET_KEY.getBytes(StandardCharsets.UTF_8);
     }
 
-    // Method to return the secret key as a String
     public static String getSecretKeyAsString() {
         return SECRET_KEY;
     }
 
-    // Generate a JWT token
     public static String generateToken(String username, String role) {
         return Jwts.builder()
                 .setSubject(username)
                 .claim("role", role)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + 3600000)) // 1 hour expiration
-                .signWith(SignatureAlgorithm.HS256, getSecretKey()) // Use byte[] for signing
+                .setExpiration(new Date(System.currentTimeMillis() + 3600000))
+                .signWith(SignatureAlgorithm.HS256, getSecretKey())
                 .compact();
     }
 
@@ -68,9 +60,7 @@ public class JwtUtil {
         }
     }
 
-
-
-    private static String stripBearerPrefix(String token) {
+    static String stripBearerPrefix(String token) {
         if (token != null && token.startsWith("Bearer ")) {
             return token.substring(7);
         }

--- a/src/test/java/com/mycompany/util/JwtUtilTest.java
+++ b/src/test/java/com/mycompany/util/JwtUtilTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class JwtUtilTest {
+  
+}

--- a/src/test/java/com/mycompany/util/JwtUtilTest.java
+++ b/src/test/java/com/mycompany/util/JwtUtilTest.java
@@ -1,4 +1,90 @@
+package com.mycompany.util;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+
 class JwtUtilTest {
-  
+
+    private static final String TEST_USERNAME = "test@example.com";
+    private static final String TEST_ROLE = "BUYER";
+
+    @BeforeEach
+    void setup() {
+        System.setProperty("ENV", "test");
+    }
+
+    @Test
+    void testGetSecretKey() {
+        String mockedSecretKey = "mockedSecretKey";
+        try (MockedStatic<JwtUtil> mockedJwtUtil = Mockito.mockStatic(JwtUtil.class)) {
+            mockedJwtUtil.when(JwtUtil::getSecretKeyAsString).thenReturn(mockedSecretKey);
+            mockedJwtUtil.when(JwtUtil::getSecretKey).thenReturn(mockedSecretKey.getBytes(StandardCharsets.UTF_8));
+
+            assertArrayEquals(mockedSecretKey.getBytes(StandardCharsets.UTF_8), JwtUtil.getSecretKey(), "Secret key bytes should match mocked value");
+        }
+    }
+
+    @Test
+    void testGetSecretKeyAsString() {
+        String mockedSecretKey = "mockedSecretKey";
+        try (MockedStatic<JwtUtil> mockedJwtUtil = Mockito.mockStatic(JwtUtil.class)) {
+            mockedJwtUtil.when(JwtUtil::getSecretKeyAsString).thenReturn(mockedSecretKey);
+
+            assertEquals(mockedSecretKey, JwtUtil.getSecretKeyAsString(), "Secret key string should match mocked value");
+        }
+    }
+
+
+
+
+    @Test
+    void testGenerateToken() {
+        String token = JwtUtil.generateToken(TEST_USERNAME, TEST_ROLE);
+        assertNotNull(token, "Token should not be null");
+        assertTrue(token.split("\\.").length == 3, "Token should have 3 parts (header, payload, signature)");
+    }
+
+    @Test
+    void testValidateToken() {
+        String token = JwtUtil.generateToken(TEST_USERNAME, TEST_ROLE);
+        Claims claims = JwtUtil.validateToken(token);
+
+        assertNotNull(claims, "Claims should not be null");
+        assertEquals(TEST_USERNAME, claims.getSubject(), "Username should match");
+        assertEquals(TEST_ROLE, claims.get("role"), "Role should match");
+    }
+
+    @Test
+    void testStripBearerPrefix() {
+        String tokenWithPrefix = "Bearer testToken";
+        String tokenWithoutPrefix = "testToken";
+
+        assertEquals("testToken", JwtUtil.stripBearerPrefix(tokenWithPrefix), "Should remove Bearer prefix");
+        assertEquals("testToken", JwtUtil.stripBearerPrefix(tokenWithoutPrefix), "Should not alter token without prefix");
+        assertNull(JwtUtil.stripBearerPrefix(null), "Should return null for null input");
+    }
+
+    @Test
+    void testExtractEmailFromToken() {
+        String token = JwtUtil.generateToken(TEST_USERNAME, TEST_ROLE);
+        String email = JwtUtil.extractEmailFromToken("Bearer " + token);
+
+        assertEquals(TEST_USERNAME, email, "Extracted email should match the username");
+    }
+
+    @Test
+    void testExtractRoleFromToken() {
+        String token = JwtUtil.generateToken(TEST_USERNAME, TEST_ROLE);
+        String role = JwtUtil.extractRoleFromToken("Bearer " + token);
+
+        assertEquals(TEST_ROLE, role, "Extracted role should match the role");
+    }
 }


### PR DESCRIPTION
This PR introduces unit tests for the JwtUtil class:

Added tests for getSecretKey and getSecretKeyAsString using Mockito-inline for mocking static methods.
Added tests for token generation, validation, and claim extraction.

Changed files:

Updated JwtUtil.java to support improved testing.
Added JwtUtilTest.java for comprehensive test coverage.
Included the mockito-inline dependency in pom.xml.

Notes for reviewers:

I used mockito inline to mock the secret key in static methods. Is this approach ok? It would be great to get your input.
