### PR TITLE
Added first test for registering buyer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,27 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+
 
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>1.0.2</version>
+            <scope>test</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>

--- a/src/test/java/com/mycompany/controller/UserResourceH2Test.java
+++ b/src/test/java/com/mycompany/controller/UserResourceH2Test.java
@@ -1,0 +1,48 @@
+package com.mycompany.controller;
+
+import com.github.javafaker.Faker;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+public class UserResourceH2Test {
+
+    private static Faker faker;
+
+    @BeforeAll
+    public static void setup() {
+        System.setProperty("quarkus.datasource.db-kind", "h2");
+        System.setProperty("quarkus.datasource.jdbc.url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        System.setProperty("quarkus.datasource.username", "sa");
+        System.setProperty("quarkus.datasource.password", "");
+        System.setProperty("quarkus.hibernate-orm.database.generation", "drop-and-create");
+
+        faker = new Faker();
+    }
+
+    @Test
+    public void testRegisterBuyerSuccess() {
+        String uniqueEmail = faker.internet().emailAddress();
+
+        String payload = String.format("""
+            {
+                "email": "%s",
+                "password": "password123",
+                "name": "Test Buyer"
+            }
+        """, uniqueEmail);
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+                .post("/auth/register/buyer")
+                .then()
+                .statusCode(200)
+                .body(containsString("User successfully registered with role: BUYER"));
+    }
+}


### PR DESCRIPTION
This pr introduces an integration test for registering a buyer using an in memory database and faker for generating a new email address for each test.

Notes for reviewers:

Hi Babette I was not able to get mocking working for unit tests on the user resource so I went with this approach let me know what you think